### PR TITLE
Fix VS Code integration when ESLint project outside VS Code project

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,15 @@
 
 var path = require('path');
 
-var rules = requireUp('eslint-local-rules.js');
+var rules = requireUp('eslint-local-rules.js', __dirname);
+
+if (!rules) {
+  throw new Error(
+    'eslint-plugin-local-rules: ' +
+    'Cannot find "eslint-local-rules.js" ' +
+    '(looking up from "' + __dirname + '").'
+  );
+}
 
 module.exports = {
   rules: rules,
@@ -13,7 +21,6 @@ module.exports = {
 // Similar to native `require` behavior, but doesn't check in `node_modules` folders
 // Based on https://github.com/js-cli/node-findup-sync
 function requireUp(filename, cwd) {
-  cwd = cwd || process.cwd();
   var filepath = path.resolve(cwd, filename);
 
   try {


### PR DESCRIPTION
When an ESLint project is not in the root directory, e.g.

```
+ our-project
|--+ client
|  |--- src/
|  |--- package.json
|  |--- eslint-local-rules.js
|--+ server
|  |--- stuff
```

Some editor plugins does not `cd` into `client` directory when invoking ESLint. Therefore `process.cwd()` is "our-project", which means `requireUp` will not find our "eslint-local-rules.js".

This problem is fixed by making this plugin require from `__dirname` instead of `process.cwd()`. Intuitively, the behavior of the plugin should not depend on where it is run.

This commit also makes `eslint-plugin-local-rules` fail loudly if the rules file is not found.