### PR TITLE
allow importing eslint-local-rules directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var path = require('path');
 
-var exts = ['js', 'cjs'];
+var exts = ['', '.cjs'];
 var rules = requireUp('eslint-local-rules', __dirname);
 
 if (!rules) {
@@ -26,7 +26,7 @@ function requireUp(filename, cwd) {
 
   for (var i = 0; i < exts.length; i++) {
     try {
-      return require(filepath + '.' + exts[i]);
+      return require(filepath + exts[i]);
     } catch(error) {
       // Ignore OS errors (will recurse to parent directory)
       if (error.code !== 'MODULE_NOT_FOUND') {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 
 var path = require('path');
 
+// Empty extension takes advantage of Node's default require behavior to check for
+// eslint-local-rules.js as well as an eslint-local-rules folder with an index.js
 var exts = ['', '.cjs'];
 var rules = requireUp('eslint-local-rules', __dirname);
 


### PR DESCRIPTION
This slightly changes the `resolveUp` logic to consider the module path without extension, to let Node.js resolve it with its own [logic][1]. Because Node.js will test for .js extension, we don't need to include it in `exts`.

This way, using a eslint-local-rules folder containing a index.js file can be used to expose local rules.  It is useful when the
eslint-local-rules.js file gets a bit big and we need to split it to separate each rule in its own file.

[1]: https://nodejs.org/api/modules.html#modules_all_together