### PR TITLE
fix/add-error-message-for-other-module-not-found

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ function requireUp(filename, cwd) {
       if (error.code !== 'MODULE_NOT_FOUND') {
         throw error;
       }
+      // Handle cases where the 'MODULE_NOT_FOUND' error was caused by a different module
+      if (!error.message.includes(`Cannot find module '${filepath + exts[i]}'`)) {
+        throw error;
+      } 
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -24,20 +24,20 @@ module.exports = {
 // Similar to native `require` behavior, but doesn't check in `node_modules` folders
 // Based on https://github.com/js-cli/node-findup-sync
 function requireUp(filename, cwd) {
-  var filepath = path.resolve(cwd, filename);
+  var filepath = path.resolve(cwd, filename) + exts[i];
 
   for (var i = 0; i < exts.length; i++) {
     try {
-      return require(filepath + exts[i]);
+      return require(filepath);
     } catch(error) {
-      // Ignore OS errors (will recurse to parent directory)
-      if (error.code !== 'MODULE_NOT_FOUND') {
+      var filepathNotFound = error.code === 'MODULE_NOT_FOUND' &&
+          error.message.includes(`Cannot find module '${filepath}'`);
+      
+      // Rethrow unless error is just saying `filepath` not found (in that case,
+      // let next loop check parent directory instead).
+      if (!filepathNotFound) {
         throw error;
       }
-      // Handle cases where the 'MODULE_NOT_FOUND' error was caused by a different module
-      if (!error.message.includes(`Cannot find module '${filepath + exts[i]}'`)) {
-        throw error;
-      } 
     }
   }
 


### PR DESCRIPTION
If there is a `require` statement in the 'eslint-local-rules' file, which results in a `MODULE_NOT_FOUND` error, its not immediately obvious with the current error messaging.

```js
// eslint-local-rules.js

// Will cause a 'MODULE_NOT_FOUND' error
require('bad-import-which-will-not-resolve');

module.exports = {
  'disallow-identifiers': {
    meta: {
      docs: {
        description: 'disallow identifiers',
        category: 'Possible Errors',
        recommended: false,
      },
      schema: [],
    },
    create: function(context) {
      return {
        Identifier: function(node) {
          context.report({
            node: node,
            message: 'Identifiers not allowed for Super Important reasons.',
          });
        },
      };
    },
  },
};
```

Will result in the following error:
```
 Error: eslint-plugin-local-rules: Cannot find "eslint-local-rules{.js,.cjs} or eslint-local-rules/index.js (checked all
    ancestors of "path/to/eslint-plugin-local-rules").
```

This PR will make it so that the `Cannot find module 'bad-import-which-will-not-resolve'` error will be thrown