### PR TITLE
feat: allow specification of plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,39 @@ module.exports = {
 };
 ```
 
+#### Specifying eslint plugin config (optional)
+
+If you need to specify additional eslint plugin config, simply place your rules in a `rules` property. You're then free
+to specify other config properties such as 
+[`processors`](https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins).
+
+```javascript
+'use strict';
+
+module.exports = {
+  rules: {
+    'disallow-identifiers': {
+      meta: {
+        // ...
+      },
+      create: function (context) {
+        // ...
+      },
+    },
+  },
+  processors: {
+    'processor-name': {
+      preprocess: function (text, filename) {
+        // ...
+      },
+      postprocess: function (messages, filename) {
+        // ...
+      },
+    },
+  },
+};
+```
+
 ### ./.eslintrc
 
 ```json

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@
 var { requireUp } = require('./requireUp');
 var { DEFAULT_EXTENSIONS } = require('./constants');
 
-var rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, __dirname);
+var config = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, __dirname);
 
-if (!rules) {
+if (!config) {
   throw new Error(
     'eslint-plugin-local-rules: ' +
       'Cannot find "eslint-local-rules{' +
@@ -18,6 +18,10 @@ if (!rules) {
   );
 }
 
-module.exports = {
-  rules: rules,
-};
+if (config.rules) {
+  module.exports = config;
+} else {
+  module.exports = {
+    rules: config,
+  };
+}


### PR DESCRIPTION
I found the need to specify [`processors`](https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins) for some rules I've been writing, but realised it wasn't (yet) possible to do this with this package.

This PR is backwards compatible, you can continue to specify rules directly as the export. If you want to specify any additional plugin config, you can do so by specifying rules under a `rules` property and then specify any other plugin config props as siblings:

```js
module.exports = {
  rules: {
    // ...
  },
  processors: {
    // ...
  },
};
