### PR TITLE
docs: link to eslint-plugin-local for plugin config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ module.exports = {
 }
 ```
 
+### General eslint plugin config
+
+If you need to specify additional eslint plugin config such as 
+[`processors`](https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins), consider using 
+https://github.com/taskworld/eslint-plugin-local. 
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Workaround for https://github.com/eslint/eslint/issues/8769 (previously https://
 ## Other solutions
 
 - https://github.com/taskworld/eslint-plugin-local
+  - Allows specifying additonal plugin config such as 
+    [`processors`](https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins)
 - https://github.com/not-an-aardvark/eslint-plugin-rulesdir
   - Allows for a custom rules directory name
 
@@ -62,12 +64,6 @@ module.exports = {
   }
 }
 ```
-
-### General eslint plugin config
-
-If you need to specify additional eslint plugin config such as 
-[`processors`](https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins), consider using 
-https://github.com/taskworld/eslint-plugin-local. 
 
 ## License
 


### PR DESCRIPTION
For those (like me) not aware that [eslint-plugin-local](https://github.com/taskworld/eslint-plugin-local) supports plugin config. 