### PR TITLE
Feat work in the workspace

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,12 @@
 var { requireUp } = require('./requireUp');
 var { DEFAULT_EXTENSIONS } = require('./constants');
 
-var rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, __dirname);
+// First check for local rules in the current working directory and its ancestors (enables npm/yarn workspaces support)
+var rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, process.cwd());
 
 if (!rules) {
-  rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, process.cwd());
+  // Then try the directory containing this plugin and its ancestors
+  rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, __dirname);
 }
 
 if (!rules) {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ if (!rules) {
       ['.js'].concat(DEFAULT_EXTENSIONS.filter(Boolean)) +
       '} ' +
       'or eslint-local-rules/index.js (checked all ancestors of "' +
+      process.cwd() +
+      '" and "' +
       __dirname +
       '").'
   );

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var { DEFAULT_EXTENSIONS } = require('./constants');
 var rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, __dirname);
 
 if (!rules) {
+  rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, process.cwd());
+}
+
+if (!rules) {
   throw new Error(
     'eslint-plugin-local-rules: ' +
       'Cannot find "eslint-local-rules{' +

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var { requireUp } = require('./requireUp');
 var { DEFAULT_EXTENSIONS } = require('./constants');
 
-// First check for local rules in the current working directory and its ancestors (enables npm/yarn workspaces support)
+// First check for local rules in the current working directory and its ancestors (enables npm/yarn/pnpm workspaces support)
 var rules = requireUp('eslint-local-rules', DEFAULT_EXTENSIONS, process.cwd());
 
 if (!rules) {


### PR DESCRIPTION
#17

The current configuration doesn't seem to work when using workspaces.
If the file is not found in `__dirname`, it also uses `process.cwd()` to make the file discoverable.
